### PR TITLE
Rename cinematic module to kinematics

### DIFF
--- a/TankSimulator/src/lib/core/systemsManager.py
+++ b/TankSimulator/src/lib/core/systemsManager.py
@@ -3,7 +3,7 @@
 import threading
 import time
 
-from lib.cinematic import cinematicManager
+from lib.kinematics import kinematicsManager
 from lib.entity import entityManager
 from lib.fuel import fuelManager
 from lib.simulation import simulationManager
@@ -13,8 +13,8 @@ class SystemsManager:
     def __init__(self):
         self.entity_system = entityManager.EntityManager()
         self.fuel_system = fuelManager.FuelManager()
-        self.cinematic_system = cinematicManager.CinematicManager()
-        self.simulation_system = simulationManager.SimulationManager(self.cinematic_system)
+        self.kinematics_system = kinematicsManager.KinematicsManager()
+        self.simulation_system = simulationManager.SimulationManager(self.kinematics_system)
         self.weapon_system = None
         self.comm_system = None
         self.sensors_system = None
@@ -34,7 +34,7 @@ class SystemsManager:
             if self.simulation_system.exercise_status == simulationManager.ExerciseStatus.RUNNING:
                 self._process_movement(simulation_frequency)
 
-                #print(self.cinematic_system.get_information())
+                #print(self.kinematics_system.get_information())
                 #print("Current fuel: " + str(self.fuel_system.engine_fuel.fuelQuantity))
 
                 self.exercise_time += 1
@@ -46,7 +46,7 @@ class SystemsManager:
     
     def _process_movement(self, simulation_frequency):
         if self.fuel_system.engine_fuel.fuelQuantity > 0:
-            distance_traveled = self.cinematic_system.process_cinematics(simulation_frequency / 1000)
+            distance_traveled = self.kinematics_system.process_kinematics(simulation_frequency / 1000)
             self.fuel_system.process_fuel_consumption(distance_traveled)
 
     def run(self):

--- a/TankSimulator/src/lib/kinematics/kinematicsManager.py
+++ b/TankSimulator/src/lib/kinematics/kinematicsManager.py
@@ -8,7 +8,7 @@ from opendis.dis7 import Vector3Float, Vector3Double, EulerAngles
 
 __author__ = "EnriqueMoran"
 
-class CinematicManager:
+class KinematicsManager:
 
     def __init__(self):
         orientation = EulerAngles()    # Set valid 0, 0, 0 orientation
@@ -110,7 +110,7 @@ class CinematicManager:
         speed = entityManager.EntityManager().get_entity_linear_velocity()
         return math.sqrt(speed.x**2 + speed.y**2 + speed.z**2)
 
-    def process_cinematics(self, dt):
+    def process_kinematics(self, dt):
         """
         :param dt: Time elapsed since last update in seconds.
         Does not calculate new Altitude.

--- a/TankSimulator/src/lib/simulation/simulationManager.py
+++ b/TankSimulator/src/lib/simulation/simulationManager.py
@@ -30,7 +30,7 @@ class ExerciseStatus(Enum):
 
 class SimulationManager:
 
-    def __init__(self, cinematic_system=None):
+    def __init__(self, kinematics_system=None):
         self.exercise_time = 0
         self.exercise_status = ExerciseStatus.UNINITIALIZED
         self.multicast_manager = None
@@ -42,7 +42,7 @@ class SimulationManager:
         self.site_id = 0
         self.entity_id = 0
         self.pdu_filter_list = []
-        self.cinematic_system = cinematic_system
+        self.kinematics_system = kinematics_system
         self._data_initialized = False    # Set to True when received ESPDU for the first time
         self.read_config()
         self.listen_to_pdu()

--- a/TankSimulator/src/main.py
+++ b/TankSimulator/src/main.py
@@ -25,7 +25,7 @@ class MainApp:
 if __name__ == "__main__":
     run_test = False    # Set to True to run unit tests
     if run_test:
-        tests.run_cinematic_tests()
+        tests.run_kinematics_tests()
     else:
         app = MainApp()
         app.run()

--- a/TankSimulator/tests/kinematicsManagerTest.py
+++ b/TankSimulator/tests/kinematicsManagerTest.py
@@ -4,13 +4,13 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from lib.utils import positionException
-from lib.cinematic.cinematicManager import CinematicManager
+from lib.kinematics.kinematicsManager import KinematicsManager
 
 from opendis.RangeCoordinates import GPS, rad2deg
 
-class TestCinematicManager(unittest.TestCase):
+class TestKinematicsManager(unittest.TestCase):
     def setUp(self):
-        self.c_manager = CinematicManager()
+        self.c_manager = KinematicsManager()
 
     def test_set_position(self):
         self.setUp()

--- a/TankSimulator/tests/tests.py
+++ b/TankSimulator/tests/tests.py
@@ -1,7 +1,7 @@
-import cinematicManagerTest
+import kinematicsManagerTest
 
-def run_cinematic_tests():
-    test = cinematicManagerTest.TestCinematicManager()
+def run_kinematics_tests():
+    test = kinematicsManagerTest.TestKinematicsManager()
     test.test_set_position()
     print("Set position tests passed. OK")
     test.test_set_heading()


### PR DESCRIPTION
## Summary
- rename `cinematic` module to `kinematics`
- update imports and class names
- adjust tests to use new kinematics module

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `PYTHONPATH=TankSimulator/src python3 -m unittest -v TankSimulator/tests/kinematicsManagerTest.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9e3463bc83258535e66c8be67b81